### PR TITLE
Bloquear login caso email não tenha sido verificado

### DIFF
--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -8,11 +8,8 @@ import { AuthContext } from "../../contexts/auth";
 import AuthService from "../../services/AuthService"
 import { UserLogin } from "../../commons/type";
 import { toast } from "react-hot-toast";
-import { AccountBalance } from '@material-ui/icons';
 
 export const LoginPage: React.FC = () => {
-  const [apiError, setApiError] = useState("");
-  const [pendingApiCall, setPendingApiCall] = useState(false);
   const navigate = useNavigate();
   const { handleLogin, loading } = useContext(AuthContext);
 
@@ -25,7 +22,6 @@ export const LoginPage: React.FC = () => {
   }
 
   function handleSubmit(values: { email: string; password: string }) {
-    setPendingApiCall(true);
     const userLogin: UserLogin = {
       email: values.email,
       password: values.password,
@@ -33,7 +29,6 @@ export const LoginPage: React.FC = () => {
     AuthService.login(userLogin)
       .then((response) => {
         handleLogin(response.data);
-        setPendingApiCall(false);
         navigate("/");
       })
       .catch((apiError) => {
@@ -44,8 +39,6 @@ export const LoginPage: React.FC = () => {
         } else {
           toast.error('Usuário ou senha inválidos!');
         }
-        
-        setPendingApiCall(false);
       });
   }
 

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -32,8 +32,16 @@ export const LoginPage: React.FC = () => {
         navigate("/");
       })
       .catch((apiError) => {
-        toast.error('Usuário ou senha inválidos!');
-        setApiError("Usuário ou senha inválidos!");
+        const errorData = apiError.response.data;
+
+        if(errorData === 'Email not verified'){
+          toast.error('E-mail não foi verificado');
+          setApiError("E-mail não foi verificado");
+        } else {
+          toast.error('Usuário ou senha inválidos!');
+          setApiError("Usuário ou senha inválidos!");
+        }
+        
         setPendingApiCall(false);
       });
     }

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -41,10 +41,8 @@ export const LoginPage: React.FC = () => {
 
         if(errorData === 'Email not verified'){
           toast.error('E-mail não foi verificado');
-          setApiError("E-mail não foi verificado");
         } else {
           toast.error('Usuário ou senha inválidos!');
-          setApiError("Usuário ou senha inválidos!");
         }
         
         setPendingApiCall(false);


### PR DESCRIPTION
Esse PR adiciona uma verificação da resposta de erro do login. A verificação é usada para retornar para o usuário uma mensagem mais claro do erro.

Link da tarefa: [segue o link](https://trello.com/c/iF1mxko7/26-bloquear-login-quando-e-mail-n%C3%A3o-ta-verificado)
