### PR TITLE
colocar toast no try catch

### DIFF
--- a/src/pages/profile/useProfile.ts
+++ b/src/pages/profile/useProfile.ts
@@ -73,12 +73,13 @@ export const useProfile = () => {
         if (response.data) {
           setProfessorSelected(response.data);
         }
+
+        toast.success("Sucesso ao solicitar vínculo ao professor");
       } catch (error) {
         toast.error("Falha ao solicitar vínculo ao professor");
         console.log(error);
       }
 
-      toast.success("Sucesso ao solicitar vínculo ao professor");
       loadStudentProfessorLink
 
     } else {


### PR DESCRIPTION
Quando um aluno já fez uma solicitação ou mesmo quando a solicitação já foi aceita. Tentando solicitar o front exibe notificação de sucesso e em seguida uma notificação de erro. Com isso foi movido o toast de sucesso para o try catch

Link da tarefa: [segue o link](https://trello.com/c/vauLlgnV/45-notifica%C3%A7%C3%A3o-duplicada-no-solicitar-vinculo-com-professor)
