### PR TITLE
fix: add /api no jenkings

### DIFF
--- a/Jenkinsfile-dev
+++ b/Jenkinsfile-dev
@@ -1,7 +1,7 @@
 pipeline {
 	agent any
 	environment {
-		VITE_API_BASE_URL="https://ca-api-dev.app.pb.utfpr.edu.br"
+		VITE_API_BASE_URL="https://ca-api-dev.app.pb.utfpr.edu.br/api"
 		VITE_USE_MOCKS=false
 	}
 	stages {


### PR DESCRIPTION
Estava ocorrendo um erro 405 not allowed por falta do /api.

Professor Vinicius passou essa correção.
